### PR TITLE
Add AI Router to API providers

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -232,6 +232,18 @@ _(vom großzügigsten zum kleinsten geordnet)_
 
 Diese Services bieten API-Zugriff auf coding-optimierte Modelle, die mit Tools wie Cursor, Continue.dev, Cline usw. arbeiten. Sie sind keine Standalone-Coding-Tools, sondern das AI-Backend für bestehende Tools.
 
+### [AI Router](https://ai-router.dev/de)
+
+> **OpenAI-kompatible API für Coding-Agent-Workflows**
+- Kompatibel mit Tools, die eine eigene OpenAI-Basis-URL und einen API-Key akzeptieren
+- Persönliche API-Keys, Nutzungsübersicht und authentifizierte Modellerkennung über `/v1/models`
+- Berechtigte neue Konten erhalten bis zu 5U verfügbares Guthaben; weitere 15U bleiben eingefroren und werden schrittweise durch tatsächliche API-Nutzung freigegeben
+- Täglicher Check-in: $1 + 2 % der Nutzung des Vortags, maximal $10 pro Check-in
+
+**** [Prämienbedingungen](https://ai-router.dev/de/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI-kompatible Beispiele](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **Qwen3-Coder-480B via OpenRouter**

--- a/README-es.md
+++ b/README-es.md
@@ -232,6 +232,18 @@ _(ordenados de más generosos a menos generosos)_
 
 Estos servicios proporcionan acceso API a modelos optimizados para codificación que se integran con herramientas populares de codificación con IA como Cursor, Continue.dev, Cline y otros. No proporcionan herramientas de codificación independientes sino que ofrecen el backend de IA para herramientas existentes.
 
+### [AI Router](https://ai-router.dev/es)
+
+> **API compatible con OpenAI para flujos de agentes de programación**
+- Compatible con herramientas que aceptan una URL base OpenAI personalizada y una clave API
+- Claves personales, visibilidad de uso y descubrimiento autenticado de modelos mediante `/v1/models`
+- Las cuentas nuevas elegibles reciben hasta 5U disponibles; otros 15U quedan congelados y se liberan gradualmente según el uso real de la API
+- Recompensa diaria: $1 + 2% del uso del día anterior, con un máximo de $10 por registro
+
+**** [Condiciones de las recompensas](https://ai-router.dev/es/docs/billing-quota/rewards-and-affiliate-commissions/) | [Ejemplos compatibles con OpenAI](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **Qwen3-Coder-480B vía OpenRouter**

--- a/README-fr.md
+++ b/README-fr.md
@@ -232,6 +232,18 @@ _(classés du plus généreux au moins généreux)_
 
 Ces services fournissent une API vers des modèles optimisés pour le codage qui s'intègrent avec des outils populaires comme Cursor, Continue.dev, Cline, etc. Ils ne sont pas des outils de codage autonomes mais l'IA backend pour les outils existants.
 
+### [AI Router](https://ai-router.dev/fr)
+
+> **API compatible OpenAI pour les workflows d'agents de codage**
+- Compatible avec les outils acceptant une URL de base OpenAI personnalisée et une clé API
+- Clés API personnelles, suivi de l'utilisation et découverte authentifiée des modèles via `/v1/models`
+- Les nouveaux comptes éligibles reçoivent jusqu'à 5U disponibles ; 15U supplémentaires restent gelés et sont libérés progressivement selon l'utilisation réelle de l'API
+- Récompense quotidienne : $1 + 2 % de l'utilisation de la veille, plafonnée à $10 par pointage
+
+**** [Conditions des récompenses](https://ai-router.dev/fr/docs/billing-quota/rewards-and-affiliate-commissions/) | [Exemples compatibles OpenAI](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **Qwen3-Coder-480B via OpenRouter**

--- a/README-hi.md
+++ b/README-hi.md
@@ -232,6 +232,18 @@
 
 カーソル、Continue.dev、Cline などと統合されるコード特化モデルのAPIを提供。単体ツールではなく既存ツールのAIバックエンド。
 
+### [AI Router](https://ai-router.dev/hi)
+
+> **कोडिंग एजेंट वर्कफ़्लो के लिए OpenAI-संगत API**
+- कस्टम OpenAI बेस URL और API कुंजी स्वीकार करने वाले टूल्स के साथ संगत
+- व्यक्तिगत API कुंजियां, उपयोग की जानकारी और `/v1/models` के जरिए प्रमाणित मॉडल खोज
+- पात्र नए खातों को अधिकतम 5U उपलब्ध रिवार्ड मिलता है; अतिरिक्त 15U फ्रीज़ रहता है और वास्तविक API उपयोग के अनुसार धीरे-धीरे जारी होता है
+- दैनिक चेक-इन रिवार्ड: $1 + पिछले दिन के उपयोग का 2%, प्रति चेक-इन अधिकतम $10
+
+**** [रिवार्ड की शर्तें](https://ai-router.dev/hi/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI-संगत उदाहरण](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **OpenRouter経由の Qwen3-Coder-480B**

--- a/README-ja.md
+++ b/README-ja.md
@@ -232,6 +232,18 @@
 
 Cursor, Continue.dev, Cline などと連携するコーディング特化モデルの API を提供。単体のコーディングツールではなく既存ツールのバックエンド。
 
+### [AI Router](https://ai-router.dev/jp)
+
+> **コーディングエージェント向け OpenAI 互換 API**
+- カスタム OpenAI ベース URL と API キーを設定できるツールに対応
+- 個人 API キー、使用量の確認、`/v1/models` による認証付きモデル取得
+- 対象となる新規アカウントには最大 5U の利用可能報酬が付与され、追加の 15U は凍結されたまま実際の API 利用に応じて段階的に解除
+- 毎日のチェックイン報酬：$1 + 前日の利用額の 2%、1 回あたり最大 $10
+
+**** [報酬規約](https://ai-router.dev/jp/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI 互換サンプル](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **OpenRouter 経由で Qwen3-Coder-480B**

--- a/README-ja.md
+++ b/README-ja.md
@@ -232,7 +232,7 @@
 
 Cursor, Continue.dev, Cline などと連携するコーディング特化モデルの API を提供。単体のコーディングツールではなく既存ツールのバックエンド。
 
-### [AI Router](https://ai-router.dev/jp)
+### [AI Router](https://ai-router.dev/ja)
 
 > **コーディングエージェント向け OpenAI 互換 API**
 - カスタム OpenAI ベース URL と API キーを設定できるツールに対応
@@ -240,7 +240,7 @@ Cursor, Continue.dev, Cline などと連携するコーディング特化モデ�
 - 対象となる新規アカウントには最大 5U の利用可能報酬が付与され、追加の 15U は凍結されたまま実際の API 利用に応じて段階的に解除
 - 毎日のチェックイン報酬：$1 + 前日の利用額の 2%、1 回あたり最大 $10
 
-**** [報酬規約](https://ai-router.dev/jp/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI 互換サンプル](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+**** [報酬規約](https://ai-router.dev/ja/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI 互換サンプル](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
 
 ---
 

--- a/README-pt-BR.md
+++ b/README-pt-BR.md
@@ -232,6 +232,18 @@ _(do mais generoso ao menos)_
 
 Serviços que fornecem API para modelos otimizados para código, integrando com Cursor, Continue.dev, Cline e outros. Não são ferramentas de código standalone; são o backend de IA para ferramentas existentes.
 
+### [AI Router](https://ai-router.dev/pt)
+
+> **API compatível com OpenAI para fluxos de agentes de programação**
+- Compatível com ferramentas que aceitam URL base OpenAI personalizada e chave de API
+- Chaves pessoais, visibilidade de uso e descoberta autenticada de modelos via `/v1/models`
+- Novas contas elegíveis recebem até 5U disponíveis; outros 15U ficam congelados e são liberados gradualmente conforme o uso real da API
+- Recompensa diária: $1 + 2% do uso do dia anterior, limitada a $10 por check-in
+
+**** [Termos das recompensas](https://ai-router.dev/pt/docs/billing-quota/rewards-and-affiliate-commissions/) | [Exemplos compatíveis com OpenAI](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **Qwen3-Coder-480B via OpenRouter**

--- a/README-tr.md
+++ b/README-tr.md
@@ -188,6 +188,18 @@ _(en cömert olandan en az cömerte sıralı)_
 
 Bu hizmetler Cursor, Continue.dev, Cline ve diğerleri gibi popüler AI kodlama araçları ile entegre olan kodlama için optimize edilmiş modellere API erişimi sağlar. Bağımsız kodlama araçları sunmazlar ancak mevcut araçlar için AI backend'i sağlarlar.
 
+### [AI Router](https://ai-router.dev/tr)
+
+> **Kodlama ajanı iş akışları için OpenAI uyumlu API**
+- Özel OpenAI temel URL'si ve API anahtarı kabul eden araçlarla uyumlu
+- Kişisel API anahtarları, kullanım görünürlüğü ve `/v1/models` üzerinden kimlik doğrulamalı model keşfi
+- Uygun yeni hesaplara en fazla 5U kullanılabilir ödül verilir; ek 15U dondurulmuş kalır ve gerçek API kullanımına göre kademeli olarak serbest bırakılır
+- Günlük giriş ödülü: $1 + önceki günün kullanımının %2'si, giriş başına en fazla $10
+
+**Bağlantılar:** [Ödül koşulları](https://ai-router.dev/tr/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI uyumlu örnekler](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **OpenRouter üzerinden Qwen3-Coder-480B**

--- a/README-zh.md
+++ b/README-zh.md
@@ -232,6 +232,18 @@
 
 这些服务提供编程优化模型的API访问，集成于Cursor、Continue.dev、Cline等流行AI编程工具中。它们不是独立工具，而是现有工具的AI后端。
 
+### [AI Router](https://ai-router.dev/cn)
+
+> **面向 Coding Agent 工作流的 OpenAI 兼容 API**
+- 适用于可配置自定义 OpenAI Base URL 和 API Key 的工具
+- 支持个人 API Key、用量查询及通过 `/v1/models` 鉴权获取模型列表
+- 符合条件的新账号最多可获得 5U 可用奖励；另有 15U 保持冻结，并随实际 API 使用逐步释放
+- 每日签到奖励：$1 + 昨日消费的 2%，单次签到封顶 $10
+
+**** [奖励条款](https://ai-router.dev/cn/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI 兼容示例](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **通过 OpenRouter 访问 Qwen3-Coder-480B**

--- a/README.md
+++ b/README.md
@@ -232,6 +232,18 @@ _(ordered from most generous to least)_
 
 These services provide API access to coding-optimized models that integrate with popular AI coding tools like Cursor, Continue.dev, Cline, and others. They don't provide standalone coding tools but offer the AI backend for existing tools.
 
+### [AI Router](https://ai-router.dev/)
+
+> **OpenAI-compatible API for coding-agent workflows**
+- Compatible with tools that accept a custom OpenAI base URL and API key
+- Personal API keys, usage visibility, and authenticated `/v1/models` discovery
+- Eligible new accounts receive up to 5U available reward; an additional 15U remains frozen and is released gradually from actual API usage
+- Daily check-in reward: $1 + 2% of the previous day's usage, capped at $10 per check-in
+
+**** [Reward terms](https://ai-router.dev/docs/billing-quota/rewards-and-affiliate-commissions/) | [OpenAI-compatible examples](https://github.com/airouter-dev/ai-router-openai-compatible-examples)
+
+---
+
 ### [OpenRouter](https://openrouter.ai/)
 
 > **Qwen3-Coder-480B via OpenRouter**


### PR DESCRIPTION
## Summary

Adds AI Router to the API Providers section in nine existing language editions:

- English
- German
- French
- Brazilian Portuguese
- Spanish
- Chinese
- Japanese
- Hindi
- Turkish

Each entry links to its matching localized landing page and public reward terms. The Japanese entry uses the canonical Japanese path, `https://ai-router.dev/ja/`. The wording distinguishes the available 5U reward from the additional frozen 15U that is released gradually through actual API usage.

## Why it fits

AI Router provides an OpenAI-compatible API relay for coding tools and agents that accept a custom base URL and API key. It includes personal API keys, usage visibility, and authenticated model discovery through `/v1/models`.

## Sources

- Public reward terms: https://ai-router.dev/docs/billing-quota/rewards-and-affiliate-commissions/
- OpenAI-compatible examples: https://github.com/airouter-dev/ai-router-openai-compatible-examples

## Validation

- Verified all nine localized landing pages and reward-term pages return HTTP 200.
- Verified the Japanese link renders `ja-JP` and has canonical URL `https://ai-router.dev/ja/`.
- `git diff --check`

## Disclosure

Submitted on behalf of AI Router. No affiliate or sponsored-placement arrangement is involved.